### PR TITLE
[Fix] 🍺 QA 피드백 반영

### DIFF
--- a/src/components/Header/ReservationDetailHeader.tsx
+++ b/src/components/Header/ReservationDetailHeader.tsx
@@ -3,7 +3,7 @@ import { ReactComponent as Refresh } from '@/assets/icons/reservation/refresh2.s
 
 function ReservationDetailHeader() {
   return (
-    <div className='mt-6 flex w-full items-center justify-between'>
+    <div className='flex w-full items-center justify-between justify-self-center pb-4 pt-6'>
       <Refresh className='h-[1.75rem] lg:h-[2.1875rem]' />
       <CloseButton location='reservation/visit' />
     </div>

--- a/src/components/ui/direction.tsx
+++ b/src/components/ui/direction.tsx
@@ -54,7 +54,8 @@ export const DirectionButton = ({
       </div>
       <span
         className={cn(
-          'text-[0.8715rem] font-normal',
+          'font-normal',
+          variant === 'square' ? 'text-[0.8715rem]' : 'text-[1rem]',
           variant === 'square' ? 'text-white' : 'text-[#5b5b5b]'
         )}
       >

--- a/src/pages/BranchDetail/index.tsx
+++ b/src/pages/BranchDetail/index.tsx
@@ -177,7 +177,7 @@ export function BranchDetailPage() {
           </div>
         </div>
         {reserved ? (
-          <div className='mt-16 flex h-[3.75rem] gap-x-[1.0625rem] px-[1.875rem]'>
+          <div className='mt-8 flex h-[3.75rem] gap-x-[1.0625rem] px-[1.875rem]'>
             <Modalbutton
               buttonTitle='예약 취소'
               buttonVariant='ghost'
@@ -195,7 +195,7 @@ export function BranchDetailPage() {
             </Button>
           </div>
         ) : (
-          <div className='mt-16 flex items-center justify-center px-4'>
+          <div className='mt-8 flex items-center justify-center px-4'>
             <Button onClick={moveToReservation}>예약하기</Button>
           </div>
         )}

--- a/src/pages/BranchDetail/index.tsx
+++ b/src/pages/BranchDetail/index.tsx
@@ -122,7 +122,7 @@ export function BranchDetailPage() {
             <h2 className='text-xl font-bold'>기본정보</h2>
             <DirectionButton onClick={handleDirection} />
           </div>
-          <div className='list-none'>
+          <ul className='list-none'>
             <li className='mt-4 flex items-center justify-start gap-2'>
               <Addrss width={20} height={23} className='relative' />
               <span className="font-['Inter'] text-base font-semibold text-[#464646]">
@@ -141,7 +141,7 @@ export function BranchDetailPage() {
                 {tel}
               </span>
             </li>
-          </div>
+          </ul>
         </div>
         <div className='h-2 w-full bg-[#eeeeee]'></div>
         <div className='w-[90%] justify-self-center py-8'>

--- a/src/pages/BranchDetail/index.tsx
+++ b/src/pages/BranchDetail/index.tsx
@@ -117,12 +117,12 @@ export function BranchDetailPage() {
       <main>
         <BankImg />
         {/* <img src={branch} alt='bank image' className='w-full' /> */}
-        <div className='border-b p-8'>
+        <div className='w-[90%] justify-self-center border-b py-8'>
           <div className='flex items-center justify-between'>
             <h2 className='text-xl font-bold'>기본정보</h2>
             <DirectionButton onClick={handleDirection} />
           </div>
-          <ul className='list-none'>
+          <div className='list-none'>
             <li className='mt-4 flex items-center justify-start gap-2'>
               <Addrss width={20} height={23} className='relative' />
               <span className="font-['Inter'] text-base font-semibold text-[#464646]">
@@ -141,10 +141,10 @@ export function BranchDetailPage() {
                 {tel}
               </span>
             </li>
-          </ul>
+          </div>
         </div>
         <div className='h-2 w-full bg-[#eeeeee]'></div>
-        <div className='p-8'>
+        <div className='w-[90%] justify-self-center py-8'>
           <h3 className='text-left text-xl font-bold'>대기 정보</h3>
           <div className='mt-8 grid grid-cols-2 gap-2 text-sm'>
             <div className='flex items-center gap-2'>
@@ -177,25 +177,25 @@ export function BranchDetailPage() {
           </div>
         </div>
         {reserved ? (
-          <div className='mt-8 flex h-[3.75rem] gap-x-[1.0625rem] px-[1.875rem]'>
+          <div className='mt-8 flex h-[3.75rem] w-[90%] gap-x-[1.0625rem] justify-self-center'>
             <Modalbutton
               buttonTitle='예약 취소'
               buttonVariant='ghost'
-              buttonSize='w-1/4 h-full'
+              buttonSize='w-1/4 '
               modalTitle='영업점 예약 취소'
               modalDescription1='취소 시 30분 후부터 재예약이 가능합니다.'
               modalDescription2=''
               modalButtonTitle='확인'
             ></Modalbutton>
             <Button
-              className='h-full w-3/4 font-bold'
+              className='w-3/4 font-bold'
               onClick={(e) => handlePage(e)('/register/visit/1')}
             >
               예약 상세보기
             </Button>
           </div>
         ) : (
-          <div className='mt-8 flex items-center justify-center px-4'>
+          <div className='mt-8 flex w-[90%] items-center justify-self-center'>
             <Button onClick={moveToReservation}>예약하기</Button>
           </div>
         )}

--- a/src/pages/Reservation/Visit/index.tsx
+++ b/src/pages/Reservation/Visit/index.tsx
@@ -12,7 +12,7 @@ export function ReservationVisitPage() {
     navigate(`/reservation/visit/${id}`);
   };
   return (
-    <div className='h-full w-full overflow-auto'>
+    <div className='h-full w-full overflow-auto pb-[5.5rem]'>
       <hr />
       <div className=''>
         {visitNum.map(({ id, my_num, name, waiting_number, waiting_time }) => (
@@ -23,7 +23,7 @@ export function ReservationVisitPage() {
             >
               <div className='mx-2 flex justify-between'>
                 <div className='text-2xl font-bold text-[#464646]'>{name}</div>
-                <div className='text-3xl font-bold text-[#008485]/80'>
+                <div className='text-3xl font-[1000] text-[#008485]/80'>
                   {my_num}
                 </div>
               </div>

--- a/src/pages/ReservationDetail/Visit/index.tsx
+++ b/src/pages/ReservationDetail/Visit/index.tsx
@@ -35,10 +35,10 @@ export function ReservationDetailVisitPage() {
   };
   return (
     <>
-      <div className='h-screen w-[90%] justify-self-center'>
+      <div className='h-full w-[90%] justify-self-center'>
         <ReservationDetailHeader />
         <div className='flex h-full w-full flex-col'>
-          <div className='flex h-full w-full flex-col justify-between'>
+          <div className='flex h-full w-full flex-col justify-between gap-12'>
             <div className='flex w-full flex-col items-center'>
               <div className='mt-4 flex justify-center'>
                 <Check className='h-auto w-[4.5rem]' />
@@ -101,6 +101,6 @@ export function ReservationDetailVisitPage() {
       </div>
 
       <Nav />
-    </div>
+    </>
   );
 }

--- a/src/pages/ReservationDetail/Visit/index.tsx
+++ b/src/pages/ReservationDetail/Visit/index.tsx
@@ -95,11 +95,13 @@ export function ReservationDetailVisitPage() {
                 {branchId}
                 <span className='text-[2rem] font-bold'>번</span>
               </div>
-              <div className='mt-2 flex w-full justify-center gap-6'>
-                <div className='text-2xl font-semibold'>하나은행 성수역점</div>
+              <div className='mt-2 flex w-full justify-center gap-6 align-middle'>
+                <div className='flex items-center text-2xl font-semibold'>
+                  하나은행 성수역점
+                </div>
                 <DirectionButton onClick={handleDirection} />
               </div>
-              <div className='mt-6 w-[21.25rem] rounded-[1.25rem] border border-[#d9d9d9] bg-[#f9f9f9] p-6'>
+              <div className='mt-6 w-[94%] rounded-[1.25rem] border border-[#d9d9d9] bg-[#f9f9f9] p-6'>
                 <h3 className='flex text-xl font-bold text-black'>대기정보</h3>
                 <hr className='my-3' />
                 <div className='flex justify-between'>
@@ -116,11 +118,11 @@ export function ReservationDetailVisitPage() {
                 </div>
               </div>
             </div>
-            <div className='w-full pb-[7rem]'>
+            <div className='w-full pb-[12rem]'>
               <Modalbutton
                 buttonTitle='예약 취소'
                 buttonVariant='outline'
-                buttonSize='h-[3.75rem] w-[23.75rem] md:w-[25rem] rounded-[1.25rem]'
+                buttonSize='h-[3.75rem] w-[94%] md:w-[25rem] rounded-[1.25rem]'
                 modalTitle='영업점 예약 취소'
                 modalDescription1='취소 시 30분 후부터 재예약이 가능합니다.'
                 modalDescription2=''


### PR DESCRIPTION
## ✨ Related Issue

- close #이슈번호
  <br/>

## 📝 기능 설명

 - reservation/call/1 : 모바일 화면 아닐 떄 위에 헤더가 깨짐 - 해결
 - reservation/visit/id : 한번 확인 해주세요 - 화면 높이 문제는 해결했는데 또 다른거  이상있었나요?
 - branch/branchId : padding으로 주지 말고 겉에 div에 w-90%로 주기 - 해결
 - reservation/visit : 은행명 폰트 크기, 번호 크기 텍스트 볼드 처리 해주세요 - 이미 볼드 처리 되있는거라서 더 두껍게가 안돼요..
                           + 목록 밑에 padding이 안들어가서 네비바에 가려져요 - 해결

  <br/>

## 🐥 추가적인 언급 사항
